### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/0_NEPTUNE/templates/main.yaml
+++ b/0_NEPTUNE/templates/main.yaml
@@ -174,7 +174,7 @@ Conditions:
       - ''
 Globals:
   Function:
-    Runtime: nodejs8.10
+    Runtime: nodejs10.x
     Handler: index.handler
     Environment:
       Variables: 


### PR DESCRIPTION
CloudFormation templates in aws-appsync-calorie-tracker-workshop have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.